### PR TITLE
Revert SimpleStorage test to previous default entry point name

### DIFF
--- a/test/simpleStorage.test.js
+++ b/test/simpleStorage.test.js
@@ -3,7 +3,7 @@ const SimpleStorage = artifacts.require("SimpleStorage");
 contract("SimpleStorage", () => {
   it("...should store the integer 89.", async () => {
     const simpleStorageInstance = await SimpleStorage.deployed();
-    await simpleStorageInstance.default(89);
+    await simpleStorageInstance.main(89);
     const storedInt = await simpleStorageInstance.storage();
 
     assert.equal(storedInt, 89, "The integer 89 was not stored.");


### PR DESCRIPTION
Tests are failing on a fresh clone. The culprit seems to be an invocation of the default smart contract entry point via the deprecated default entry point name (`main` vs `default`).

https://github.com/ecadlabs/taquito/commit/11e44ba57c3782dd2b2a0cc94c407bc35629bfec#diff-ec3c4d00d89b1b22d6171613d10edd8a824e9b3209426b775efe4b391109a144L93

Would either need to upgrade the taquito dependency (> 7.0.0.) or accept this PR to repair functionality.